### PR TITLE
[R5U-1797] Add rails 5.2 support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-name: repo-checks
+name: spec
 
 on: push
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,27 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'bump/tasks'
-require 'wwtd/tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+desc "Bundle all gemfiles"
+task :bundle_all do
+  Bundler.with_original_env do
+    Dir["gemfiles/*.gemfile"].each do |gemfile|
+      sh "BUNDLE_GEMFILE=#{gemfile} matching_bundle"
+    end
+  end
+end
+
+
+desc "Run specs under all Gemfiles"
+task :spec_all do
+  Bundler.with_original_env do
+    Dir["gemfiles/*.gemfile"].each do |gemfile|
+      sh "BUNDLE_GEMFILE=#{gemfile} rake"
+    end
+  end
+end

--- a/Readme.md
+++ b/Readme.md
@@ -45,4 +45,4 @@ Author
 [Michael Grosser](http://grosser.it)<br/>
 michael@grosser.it<br/>
 License: MIT<br/>
-[![Build Status](https://github.com/zendesk/delta_changes/workflows/spec/badge.svg)](https://travis-ci.org/zendesk/delta_changes/actions)
+[![Build Status](https://github.com/zendesk/delta_changes/workflows/spec/badge.svg)](https://github.com/zendesk/delta_changes/actions)

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.license = 'MIT'
   s.files = Dir.glob('lib/**/*')
 
-  s.add_runtime_dependency 'activerecord', '>= 3.2.22', '< 5.2'
+  s.add_runtime_dependency 'activerecord', '>= 3.2.22', '< 6.3'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'bump'
-  s.add_development_dependency 'wwtd'
   s.add_development_dependency 'byebug'
+  s.add_development_dependency 'matching_bundle'
 end

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -4,3 +4,4 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 4.2.11'
 gem 'bigdecimal', '1.3.5'
+gem 'sqlite3', '~> 1.3.13'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../'
 
 gem 'activerecord', '~> 5.0.1'
+gem 'sqlite3', '~> 1.3.13'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 5.1.7'
+gem 'activerecord', '~> 5.2.4'
 gem 'sqlite3', '~> 1.3.13'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.0.3'
+gem 'sqlite3', '~> 1.4'

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.1'
+gem 'sqlite3', '~> 1.4'

--- a/lib/delta_changes.rb
+++ b/lib/delta_changes.rb
@@ -6,7 +6,11 @@ module DeltaChanges
       base.extend(ClassMethods)
       base.cattr_accessor :delta_changes_options
       base.attribute_method_suffix '_delta_changed?', '_delta_change', '_delta_was', '_delta_will_change!'
-      base.send(:prepend, InstanceMethods)
+      if ::ActiveRecord.version < Gem::Version.new('5.2')
+        base.send(:prepend, InstanceMethodsLegacy)
+      else
+        base.send(:prepend, InstanceMethods)
+      end
     end
 
     module ClassMethods
@@ -41,7 +45,8 @@ module DeltaChanges
       end
     end
 
-    module InstanceMethods
+    # Rails < 5.2
+    module InstanceMethodsLegacy
       # Wrap write_attribute to remember original attribute value.
       def write_attribute(attr, value)
         attr = attr.to_s
@@ -57,6 +62,27 @@ module DeltaChanges
           delta_changed_attributes.delete(attr) unless delta_changes_field_changed?(attr, old, value)
         else
           old = respond_to?(:clone_attribute_value) ? clone_attribute_value(:read_attribute, attr) : read_attribute(attr).dup
+          super(attr, value)
+          delta_changed_attributes[attr] = old if delta_changes_field_changed?(attr, old, value)
+        end
+      end
+    end
+
+    module InstanceMethods
+      def _write_attribute(attr, value)
+         attr = attr.to_s
+
+        unless self.class.delta_changes_options[:columns].include?(attr)
+          return super(attr, value)
+        end
+
+        # The attribute already has an unsaved change.
+        if delta_changed_attributes.include?(attr)
+          old = delta_changed_attributes[attr]
+          super(attr, value)
+          delta_changed_attributes.delete(attr) unless delta_changes_field_changed?(attr, old, value)
+        else
+          old = read_attribute(attr).dup
           super(attr, value)
           delta_changed_attributes[attr] = old if delta_changes_field_changed?(attr, old, value)
         end

--- a/spec/delta_changes_spec.rb
+++ b/spec/delta_changes_spec.rb
@@ -73,7 +73,7 @@ describe DeltaChanges do
 
     it 'should not reset columns on update' do
       user = User.create!(:name => 'NAME', :foo => 'FOO', :bar => 'BAR')
-      user.update_attributes(:name => 'NAME-2')
+      user.update(:name => 'NAME-2')
       expect(user.delta_changes).to eq('name' => [nil, 'NAME-2'])
     end
 


### PR DESCRIPTION
Add support for rails 5.2, 6.0, 6.1

Rails moved from using `write_attribute` to `_write_attribute` and this moves the implementation from using `alias_method` to prepending a module and using `super`.

This also fixes the name of the GitHub Actions and the badge for the CI status
This adds `bundle_all` and `spec_all` rake tasks to run through all the gemfiles using the `matching_bundle` dependency.