### PR TITLE
[R5U-1932] Ensure that the options can be passed through the generated methods.

### DIFF
--- a/lib/delta_changes.rb
+++ b/lib/delta_changes.rb
@@ -37,8 +37,8 @@ module DeltaChanges
               attribute_delta_was(tracked_attribute)
             end
 
-            define_method("#{tracked_attribute}_delta_will_change!") do
-              attribute_delta_will_change!(tracked_attribute)
+            define_method("#{tracked_attribute}_delta_will_change!") do |*args|
+              attribute_delta_will_change!(tracked_attribute, *args)
             end
           end
         end
@@ -131,7 +131,7 @@ module DeltaChanges
         value = send(attr)
         value.duplicable? ? value.clone : value
       else
-        options[:from] || respond_to?(:clone_attribute_value) ? clone_attribute_value(:read_attribute, attr) : read_attribute(attr).dup
+        options[:from] || (respond_to?(:clone_attribute_value) ? clone_attribute_value(:read_attribute, attr) : read_attribute(attr).dup)
       end
       delta_changed_attributes[attr] = attribute_value
     end

--- a/spec/delta_changes_spec.rb
+++ b/spec/delta_changes_spec.rb
@@ -58,6 +58,12 @@ describe DeltaChanges do
       expect(user.delta_changes).to eq('foo' => [1, 2])
     end
 
+    it 'should accept options' do
+      user = User.new(:name => 0)
+      user.name_delta_will_change!(from: 0)
+      expect(user.delta_changes).to eq('name' => [0, "0"])
+    end
+
     it 'should not mess with normal changes' do
       changes = User.new(:email => 'EMAIL', :name => 'NAME', :foo => 'FOO').changes
       expect(changes).to eq(


### PR DESCRIPTION
Also handles the precedence problem where the double pipe `||` his a higher precedence than the query `?`

JIRA: https://zendesk.atlassian.net/browse/R5U-1932