### PR TITLE
Add workflow for pushing to Ruby Gems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+    jobs:
+      call-workflow:
+        uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+        secrets:
+          RUBY_GEMS_API_KEY: { secrets.RUBY_GEMS_API_KEY }
+          RUBY_GEMS_TOTP_DEVICE: { secrets.RUBY_GEMS_TOTP_DEVICE }

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@ require 'bundler/gem_tasks'
 require 'bump/tasks'
 require 'rspec/core/rake_task'
 
+# Pushing to rubygems is handled by a github workflow
+ENV['gem_push'] = 'false'
+
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec


### PR DESCRIPTION
Creates a workflow for publishing to the public Zendesk RubyGems account.

Uses the workflow from the public Symbol’s value as variable is void: gw gem. Symbol’s value as variable is void: gw's (ruby-gem-publication readme](https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md)

Rakfile changes:

Calling `rake release` will:
  - build
  - tag (if everything has been committed)
  - push to the repo
  - push the gem to rubygems

Setting gem_push to false will skip the last step. We want to skip this because this is handled by a github workflow instead.

Co-authored-by: Benjamin Quorning <bquorning@zendesk.com>