### PR TITLE
Release v2.4.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,16 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.6"
           - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
         gemfile:
-          - rails5.1
-          - rails5.2
           - rails6.0
           - rails6.1
           - rails7.0
-        exclude:
-          - {ruby-version: "2.6", gemfile: rails7.0}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.homepage = 'http://github.com/zendesk/delta_changes'
   s.license = 'MIT'
   s.files = Dir.glob('lib/**/*')
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency 'activerecord', '>= 5.1', '< 7.1'
 

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.1.7'
-gem 'sqlite3', '~> 1.3.13'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.2.4'
-gem 'sqlite3', '~> 1.3.13'

--- a/lib/delta_changes/version.rb
+++ b/lib/delta_changes/version.rb
@@ -1,3 +1,3 @@
 module DeltaChanges
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
- Drops Ruby 2.7
- Drops Rails < 6.0
- Tests with Ruby 3.0, 3.1, 3.2