### PR TITLE
[TP 2086] Adds support for Rails 7.1, and Ruby 3.3. Drops Ruby 2.7 support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,14 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
         gemfile:
           - rails6.0
           - rails6.1
           - rails7.0
+          - rails7.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -7,9 +7,9 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.homepage = 'http://github.com/zendesk/delta_changes'
   s.license = 'MIT'
   s.files = Dir.glob('lib/**/*')
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 5.1', '< 7.1'
+  s.add_runtime_dependency 'activerecord', '>= 6.0', '< 7.2'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 7.1'
+gem 'sqlite3', '~> 1.4'


### PR DESCRIPTION
Adds Rails 7.1 and Ruby 3.2 support in preparation for Classic's bump to 7.1. Drops support for Ruby 2.7.  