### PR TITLE
Drop Rails < 7.0, add support for Ruby 3.4, Rails 7.2, 8.0, main

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,13 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
         gemfile:
-          - rails6.0
-          - rails6.1
           - rails7.0
           - rails7.1
     env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,9 +17,9 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -1,6 +1,10 @@
-name: spec
+name: Test against Rails main
 
-on: push
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
 
 jobs:
   specs:
@@ -13,10 +17,7 @@ jobs:
           - "3.3"
           - "3.4"
         gemfile:
-          - rails7.0
-          - rails7.1
-          - rails7.2
-          - rails8.0
+          - rails_main
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
@@ -28,18 +29,3 @@ jobs:
           bundler-cache: true
       - name: RSpec
         run: bundle exec rake spec
-
-  specs_successful:
-    name: Specs passing?
-    needs: specs
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          if ${{ needs.specs.result == 'success' }}
-          then
-            echo "All specs pass"
-          else
-            echo "Some specs failed"
-            false
-          fi

--- a/Readme.md
+++ b/Readme.md
@@ -35,9 +35,9 @@ Testing
 
 To run tests: `$ rake spec`
 
-To run tests with a specific Rails version listed in `./gemfiles`, e.g. Rails 5.0:
+To run tests with a specific Rails version listed in `./gemfiles`, e.g. Rails 7.0:
 ```
-$ BUNDLE_GEMFILE=gemfiles/rails5.0.gemfile rake spec`
+$ BUNDLE_GEMFILE=gemfiles/rails7.0.gemfile rake spec`
 ```
 
 Author

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -7,9 +7,9 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.homepage = 'http://github.com/zendesk/delta_changes'
   s.license = 'MIT'
   s.files = Dir.glob('lib/**/*')
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.3'
 
-  s.add_runtime_dependency 'activerecord', '>= 6.0', '< 7.2'
+  s.add_runtime_dependency 'activerecord', '>= 7.0', '< 7.2'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.files = Dir.glob('lib/**/*')
   s.required_ruby_version = '>= 3.3'
 
-  s.add_runtime_dependency 'activerecord', '>= 7.0', '< 7.2'
+  s.add_dependency 'activerecord', '>= 7.0'
 end

--- a/delta_changes.gemspec
+++ b/delta_changes.gemspec
@@ -10,11 +10,4 @@ Gem::Specification.new 'delta_changes', DeltaChanges::VERSION do |s|
   s.required_ruby_version = '>= 3.3'
 
   s.add_runtime_dependency 'activerecord', '>= 7.0', '< 7.2'
-
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'sqlite3', '~> 1.3.6'
-  s.add_development_dependency 'bump'
-  s.add_development_dependency 'byebug'
-  s.add_development_dependency 'matching_bundle'
 end

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+gem 'rake'
+gem 'rspec'
+gem 'bump'
+gem 'pry-byebug'
+gem 'matching_bundle'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 6.0.3'
-gem 'sqlite3', '~> 1.4'

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 6.1.1'
-gem 'sqlite3', '~> 1.4'

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -4,3 +4,5 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 7.0.0'
 gem 'sqlite3', '~> 1.4'
+
+eval_gemfile 'common.rb'

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -4,3 +4,5 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 7.1'
 gem 'sqlite3', '~> 1.4'
+
+eval_gemfile 'common.rb'

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -2,10 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 7.0.0'
-gem 'logger'
-gem 'mutex_m'
-gem 'bigdecimal'
+gem 'activerecord', '~> 7.2.0'
 gem 'sqlite3', '~> 1.4'
 
 eval_gemfile 'common.rb'

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 8.0.0'
+gem 'sqlite3', '>= 2.0'
+
+eval_gemfile 'common.rb'

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', github: 'rails/rails', branch: 'main'
+gem 'sqlite3', '>= 2.0'
+
+eval_gemfile 'common.rb'

--- a/lib/delta_changes.rb
+++ b/lib/delta_changes.rb
@@ -6,11 +6,7 @@ module DeltaChanges
       base.extend(ClassMethods)
       base.cattr_accessor :delta_changes_options
       base.attribute_method_suffix '_delta_changed?', '_delta_change', '_delta_was', '_delta_will_change!'
-      if ::ActiveRecord.version < Gem::Version.new('5.2')
-        base.send(:prepend, InstanceMethodsLegacy)
-      else
-        base.send(:prepend, InstanceMethods)
-      end
+      base.send(:prepend, InstanceMethods)
     end
 
     module ClassMethods
@@ -41,29 +37,6 @@ module DeltaChanges
               attribute_delta_will_change!(tracked_attribute, *args)
             end
           end
-        end
-      end
-    end
-
-    # Rails < 5.2
-    module InstanceMethodsLegacy
-      # Wrap write_attribute to remember original attribute value.
-      def write_attribute(attr, value)
-        attr = attr.to_s
-
-        unless self.class.delta_changes_options[:columns].include?(attr)
-          return super(attr, value)
-        end
-
-        # The attribute already has an unsaved change.
-        if delta_changed_attributes.include?(attr)
-          old = delta_changed_attributes[attr]
-          super(attr, value)
-          delta_changed_attributes.delete(attr) unless delta_changes_field_changed?(attr, old, value)
-        else
-          old = respond_to?(:clone_attribute_value) ? clone_attribute_value(:read_attribute, attr) : read_attribute(attr).dup
-          super(attr, value)
-          delta_changed_attributes[attr] = old if delta_changes_field_changed?(attr, old, value)
         end
       end
     end

--- a/lib/delta_changes.rb
+++ b/lib/delta_changes.rb
@@ -6,7 +6,7 @@ module DeltaChanges
       base.extend(ClassMethods)
       base.cattr_accessor :delta_changes_options
       base.attribute_method_suffix '_delta_changed?', '_delta_change', '_delta_was', '_delta_will_change!'
-      base.send(:prepend, InstanceMethods)
+      base.prepend(InstanceMethods)
     end
 
     module ClassMethods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'delta_changes'
+require 'logger'
 require 'active_record'
 
 require 'support/environment'


### PR DESCRIPTION
And other cleanup. See individual commits for details.